### PR TITLE
Interface tuple types handled in invocation.

### DIFF
--- a/ChainSharp.Tests/Examples/Brewery/Steps/Prepare/BrewingJug.cs
+++ b/ChainSharp.Tests/Examples/Brewery/Steps/Prepare/BrewingJug.cs
@@ -1,6 +1,6 @@
 namespace ChainSharp.Tests.Examples.Brewery.Steps.Prepare;
 
-public class BrewingJug
+public class BrewingJug : IBrewingJug
 {
     public required int Gallons { get; set; }
     

--- a/ChainSharp.Tests/Examples/Brewery/Steps/Prepare/IBrewingJug.cs
+++ b/ChainSharp.Tests/Examples/Brewery/Steps/Prepare/IBrewingJug.cs
@@ -1,0 +1,11 @@
+namespace ChainSharp.Tests.Examples.Brewery.Steps.Prepare;
+
+public interface IBrewingJug
+{
+    int Gallons { get; set; }
+    int Yeast { get; set; }
+    bool HasCinnamonSticks { get; set; }
+    bool IsFermented { get; set; }
+    bool IsBrewed { get; set; }
+    Ingredients Ingredients { get; set; }
+}

--- a/ChainSharp.Tests/Examples/Brewery/Steps/Prepare/PrepareReturnsInterface.cs
+++ b/ChainSharp.Tests/Examples/Brewery/Steps/Prepare/PrepareReturnsInterface.cs
@@ -1,0 +1,30 @@
+using ChainSharp.Exceptions;
+using ChainSharp.Tests.Examples.Brewery.Steps.Ferment;
+using LanguageExt;
+using LanguageExt.UnsafeValueAccess;
+
+namespace ChainSharp.Tests.Examples.Brewery.Steps.Prepare;
+
+public class PrepareWithInterface(IFerment ferment) : Step<Ingredients, IBrewingJug>
+{
+    public override async Task<IBrewingJug> Run(Ingredients input)
+    {
+        const int gallonWater = 1;
+
+        var gallonAppleJuice = await Boil(gallonWater, input.Apples, input.BrownSugar);
+
+        if (gallonAppleJuice.IsLeft)
+            throw gallonAppleJuice.Swap().ValueUnsafe();
+        
+        return new BrewingJug()
+        {
+            Gallons = gallonAppleJuice.ValueUnsafe(),
+            Ingredients = input
+        };
+    }
+
+    private async Task<Either<WorkflowException, int>> Boil(int gallonWater, int numApples, int ozBrownSugar)
+    {
+        return gallonWater + (numApples / 8) + (ozBrownSugar / 128);
+    }
+}

--- a/ChainSharp/ChainSharp.csproj
+++ b/ChainSharp/ChainSharp.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.5.0</Version>
+        <Version>1.5.1</Version>
         <AssemblyName>Theauxm.ChainSharp</AssemblyName>
     </PropertyGroup>
 

--- a/ChainSharp/Utils/TypeHelpers.cs
+++ b/ChainSharp/Utils/TypeHelpers.cs
@@ -1,13 +1,12 @@
-using System.Runtime.CompilerServices;
 using ChainSharp.Exceptions;
 
 namespace ChainSharp.Utils;
 
 internal static class TypeHelpers
 {
-    internal static List<dynamic> ExtractTypes(Dictionary<Type, object> memory, Type inputType)
+    internal static List<(Type, dynamic)> ExtractTypeTuples(Dictionary<Type, object> memory, Type inputType)
     {
-        var dynamicList = new List<dynamic>();
+        var dynamicList = new List<(Type, dynamic)>();
         foreach (var type in inputType.GenericTypeArguments)
         {
             var value = memory.GetValueOrDefault(type);
@@ -15,96 +14,112 @@ internal static class TypeHelpers
             if (value is null)
                 throw new WorkflowException($"Could not extract type ({type}) from Tuple. Value not in Memory.");
             
-            dynamicList.Add(value);
+            dynamicList.Add((type, value));
         }
 
         return dynamicList;
     }
 
-    internal static dynamic ConvertTwoTuple(List<dynamic> dynamicList)
+    internal static dynamic ConvertTwoTuple(List<(Type, dynamic)> dynamicList)
     {
         ArgumentNullException.ThrowIfNull(dynamicList);
 
         if (dynamicList.Count < 2)
             throw new ArgumentException("List must have at least two elements.", nameof(dynamicList));
 
-        return ValueTuple.Create(
-            dynamicList[0], 
-            dynamicList[1]);
+        var (type1, value1) = dynamicList[0];
+        var (type2, value2) = dynamicList[1];
+        
+        var tupleType = typeof(ValueTuple<,>).MakeGenericType(type1, type2);
+        return Activator.CreateInstance(tupleType, value1, value2);
     }
     
-    internal static dynamic ConvertThreeTuple(List<dynamic> dynamicList)
+    internal static dynamic ConvertThreeTuple(List<(Type, dynamic)> dynamicList)
     {
         ArgumentNullException.ThrowIfNull(dynamicList);
 
         if (dynamicList.Count < 3)
             throw new ArgumentException("List must have at least three elements.", nameof(dynamicList));
 
-        return ValueTuple.Create(
-            dynamicList[0], 
-            dynamicList[1], 
-            dynamicList[2]);
+        var (type1, value1) = dynamicList[0];
+        var (type2, value2) = dynamicList[1];
+        var (type3, value3) = dynamicList[2];
+        
+        var tupleType = typeof(ValueTuple<,,>).MakeGenericType(type1, type2, type3);
+        return Activator.CreateInstance(tupleType, value1, value2, value3);
     }
     
-    internal static dynamic ConvertFourTuple(List<dynamic> dynamicList)
+    internal static dynamic ConvertFourTuple(List<(Type, dynamic)> dynamicList)
     {
         ArgumentNullException.ThrowIfNull(dynamicList);
 
         if (dynamicList.Count < 4)
             throw new ArgumentException("List must have at least four elements.", nameof(dynamicList));
 
-        return ValueTuple.Create(
-            dynamicList[0], 
-            dynamicList[1], 
-            dynamicList[2], 
-            dynamicList[3]);
+        var (type1, value1) = dynamicList[0];
+        var (type2, value2) = dynamicList[1];
+        var (type3, value3) = dynamicList[2];
+        var (type4, value4) = dynamicList[3];
+        
+        var tupleType = typeof(ValueTuple<,,,>).MakeGenericType(type1, type2, type3, type4);
+        return Activator.CreateInstance(tupleType, value1, value2, value3, value4);
+
     }
     
-    internal static dynamic ConvertFiveTuple(List<dynamic> dynamicList)
+    internal static dynamic ConvertFiveTuple(List<(Type, dynamic)> dynamicList)
     {
         ArgumentNullException.ThrowIfNull(dynamicList);
 
         if (dynamicList.Count < 5)
             throw new ArgumentException("List must have at least five elements.", nameof(dynamicList));
 
-        return ValueTuple.Create(
-            dynamicList[0], 
-            dynamicList[1], 
-            dynamicList[2], 
-            dynamicList[3], 
-            dynamicList[4]);
+        var (type1, value1) = dynamicList[0];
+        var (type2, value2) = dynamicList[1];
+        var (type3, value3) = dynamicList[2];
+        var (type4, value4) = dynamicList[3];
+        var (type5, value5) = dynamicList[4];
+        
+        var tupleType = typeof(ValueTuple<,,,,>).MakeGenericType(type1, type2, type3, type4, type5);
+        return Activator.CreateInstance(tupleType, value1, value2, value3, value4, value5);
+
     }
     
-    internal static dynamic ConvertSixTuple(List<dynamic> dynamicList)
+    internal static dynamic ConvertSixTuple(List<(Type, dynamic)> dynamicList)
     {
         ArgumentNullException.ThrowIfNull(dynamicList);
 
         if (dynamicList.Count < 6)
             throw new ArgumentException("List must have at least six elements.", nameof(dynamicList));
 
-        return ValueTuple.Create(
-            dynamicList[0], 
-            dynamicList[1], 
-            dynamicList[2], 
-            dynamicList[3], 
-            dynamicList[4], 
-            dynamicList[5]);
+        var (type1, value1) = dynamicList[0];
+        var (type2, value2) = dynamicList[1];
+        var (type3, value3) = dynamicList[2];
+        var (type4, value4) = dynamicList[3];
+        var (type5, value5) = dynamicList[4];
+        var (type6, value6) = dynamicList[5];
+        
+        var tupleType = typeof(ValueTuple<,,,,,>).MakeGenericType(type1, type2, type3, type4, type5, type6);
+        return Activator.CreateInstance(tupleType, value1, value2, value3, value4, value5, value6);
+
     }
     
-    internal static dynamic ConvertSevenTuple(List<dynamic> dynamicList)
+    internal static dynamic ConvertSevenTuple(List<(Type, dynamic)> dynamicList)
     {
         ArgumentNullException.ThrowIfNull(dynamicList);
 
         if (dynamicList.Count < 6)
             throw new ArgumentException("List must have at least six elements.", nameof(dynamicList));
 
-        return ValueTuple.Create(
-            dynamicList[0], 
-            dynamicList[1], 
-            dynamicList[2], 
-            dynamicList[3], 
-            dynamicList[4], 
-            dynamicList[5],
-            dynamicList[6]);
+        var (type1, value1) = dynamicList[0];
+        var (type2, value2) = dynamicList[1];
+        var (type3, value3) = dynamicList[2];
+        var (type4, value4) = dynamicList[3];
+        var (type5, value5) = dynamicList[4];
+        var (type6, value6) = dynamicList[5];
+        var (type7, value7) = dynamicList[6];
+        
+        var tupleType = typeof(ValueTuple<,,,,,,>).MakeGenericType(type1, type2, type3, type4, type5, type6, type7);
+        return Activator.CreateInstance(tupleType, value1, value2, value3, value4, value5, value6, value7);
+
     }
 } 

--- a/ChainSharp/Workflow.cs
+++ b/ChainSharp/Workflow.cs
@@ -467,17 +467,17 @@ public abstract class Workflow<TInput, TReturn> : IWorkflow<TInput, TReturn>
     
     private dynamic ExtractTuple(Type inputType)
     {
-        var dynamicList = TypeHelpers.ExtractTypes(Memory, inputType);
+        var typeTuples = TypeHelpers.ExtractTypeTuples(Memory, inputType);
 
-        return dynamicList.Count switch
+        return typeTuples.Count switch
         {
             0 => throw new WorkflowException($"Cannot have Tuple of length 0."),
-            2 => TypeHelpers.ConvertTwoTuple(dynamicList),
-            3 => TypeHelpers.ConvertThreeTuple(dynamicList),
-            4 => TypeHelpers.ConvertFourTuple(dynamicList),
-            5 => TypeHelpers.ConvertFiveTuple(dynamicList),
-            6 => TypeHelpers.ConvertSixTuple(dynamicList),
-            7 => TypeHelpers.ConvertSevenTuple(dynamicList),
+            2 => TypeHelpers.ConvertTwoTuple(typeTuples),
+            3 => TypeHelpers.ConvertThreeTuple(typeTuples),
+            4 => TypeHelpers.ConvertFourTuple(typeTuples),
+            5 => TypeHelpers.ConvertFiveTuple(typeTuples),
+            6 => TypeHelpers.ConvertSixTuple(typeTuples),
+            7 => TypeHelpers.ConvertSevenTuple(typeTuples),
             _ => throw new WorkflowException($"Could not create Tuple for type ({inputType})")
         };
     } 


### PR DESCRIPTION
Here is a snippet example that shows this error. This may really just be a C# weakness.

(This is from VS Code Notebook)

```csharp

using System;

public interface IMyInterface
{
    void DoSomething();
}

public class MyClass : IMyInterface
{
    public void DoSomething()
    {
        Console.WriteLine("Doing something!");
    }
}

public class TestClass
{
    public void ProcessStep((IMyInterface, string) input)
    {
        Console.WriteLine(input);
    }
}

var instance = new MyClass();
var tupleWithInstance = (instance, "SomeValue");

var testClassInstance = new TestClass();

var methodInfo = typeof(TestClass).GetMethod("ProcessStep");

// This should simulate the invocation and result in a runtime exception
try
{
    var result = methodInfo.Invoke(testClassInstance, new object[] { tupleWithInstance }); // This will fail

    Console.WriteLine($"Result: {castedResult.Item1.GetType().Name}, {castedResult.Item2}");
}
catch (Exception ex)
{
    Console.WriteLine($"Exception: {ex.Message}");
}
```
This throws with this exception:

```Exception: Object of type 'System.ValueTuple`2[Submission#11+MyClass,System.String]' cannot be converted to type 'System.ValueTuple`2[Submission#3+IMyInterface,System.String]'.```

I resolve this by explicitly casting the tuple back to the interface that was originally passed in.