### PR TITLE
feature: Stack Trace Updates

### DIFF
--- a/ChainSharp.Tests.Integration/IntegrationTests/WorkflowTests.cs
+++ b/ChainSharp.Tests.Integration/IntegrationTests/WorkflowTests.cs
@@ -1,3 +1,4 @@
+using ChainSharp.Exceptions;
 using ChainSharp.Step;
 using ChainSharp.Tests.Examples.Brewery;
 using ChainSharp.Tests.Examples.Brewery.Steps.Bottle;
@@ -318,6 +319,24 @@ public class WorkflowTests : TestSetup
         workflow.Memory.Should().NotBeNull();
         result.Should().NotBeNull();
     }
+    
+    [Theory]
+    public async Task TestWithException()
+    {
+        // Arrange
+        var workflow = new ChainTestWithException();
+
+        // Act
+        // Assert
+
+        Assert.ThrowsAsync<WorkflowException>(async () => await workflow.Run(Unit.Default));
+    }
+    
+    private class ThrowsStep : Step<Unit, Unit>
+    {
+        public override Task<Unit> Run(Unit input)
+            => throw new WorkflowException("This is a workflow exception.");
+    }
 
     private class OuterProperty
     {
@@ -615,5 +634,14 @@ public class WorkflowTests : TestSetup
                 .Chain<Bottle>()
                 .Resolve();
         }
+    }
+    
+    private class ChainTestWithException
+        : Workflow<Unit, Unit>
+    {
+        protected override async Task<Either<Exception, Unit>> RunInternal(Unit input)
+            => Activate(input)
+                .Chain<ThrowsStep>()
+                .Resolve();
     }
 }

--- a/ChainSharp.Tests.Integration/IntegrationTests/WorkflowTests.cs
+++ b/ChainSharp.Tests.Integration/IntegrationTests/WorkflowTests.cs
@@ -319,7 +319,7 @@ public class WorkflowTests : TestSetup
         workflow.Memory.Should().NotBeNull();
         result.Should().NotBeNull();
     }
-    
+
     [Theory]
     public async Task TestWithException()
     {
@@ -331,11 +331,11 @@ public class WorkflowTests : TestSetup
 
         Assert.ThrowsAsync<WorkflowException>(async () => await workflow.Run(Unit.Default));
     }
-    
+
     private class ThrowsStep : Step<Unit, Unit>
     {
-        public override Task<Unit> Run(Unit input)
-            => throw new WorkflowException("This is a workflow exception.");
+        public override Task<Unit> Run(Unit input) =>
+            throw new WorkflowException("This is a workflow exception.");
     }
 
     private class OuterProperty
@@ -635,13 +635,10 @@ public class WorkflowTests : TestSetup
                 .Resolve();
         }
     }
-    
-    private class ChainTestWithException
-        : Workflow<Unit, Unit>
+
+    private class ChainTestWithException : Workflow<Unit, Unit>
     {
-        protected override async Task<Either<Exception, Unit>> RunInternal(Unit input)
-            => Activate(input)
-                .Chain<ThrowsStep>()
-                .Resolve();
+        protected override async Task<Either<Exception, Unit>> RunInternal(Unit input) =>
+            Activate(input).Chain<ThrowsStep>().Resolve();
     }
 }

--- a/ChainSharp/Step/Step.cs
+++ b/ChainSharp/Step/Step.cs
@@ -21,11 +21,17 @@ public abstract class Step<TIn, TOut> : IStep<TIn, TOut>
         }
         catch (Exception e)
         {
-            var messageField = typeof(Exception).GetField("_message", BindingFlags.Instance | BindingFlags.NonPublic);
-    
+            var messageField = typeof(Exception).GetField(
+                "_message",
+                BindingFlags.Instance | BindingFlags.NonPublic
+            );
+
             if (messageField != null)
-                messageField.SetValue(e, $"{{ \"Step\": \"{GetType().Name}\", \"Type\": \"{e.GetType().Name}\", \"Message\": \"{e.Message}\" }}");            
-            
+                messageField.SetValue(
+                    e,
+                    $"{{ \"Step\": \"{GetType().Name}\", \"Type\": \"{e.GetType().Name}\", \"Message\": \"{e.Message}\" }}"
+                );
+
             Console.WriteLine($"Step: ({GetType().Name}) failed with Exception: ({e.Message})");
             return e;
         }

--- a/ChainSharp/Step/Step.cs
+++ b/ChainSharp/Step/Step.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using LanguageExt;
 using LanguageExt.UnsafeValueAccess;
 
@@ -20,8 +21,13 @@ public abstract class Step<TIn, TOut> : IStep<TIn, TOut>
         }
         catch (Exception e)
         {
-            Console.WriteLine($"Found Exception ({e.InnerException ?? e})");
-            return e.InnerException ?? e;
+            var messageField = typeof(Exception).GetField("_message", BindingFlags.Instance | BindingFlags.NonPublic);
+    
+            if (messageField != null)
+                messageField.SetValue(e, $"{{ \"Step\": \"{GetType().Name}\", \"Type\": \"{e.GetType().Name}\", \"Message\": \"{e.Message}\" }}");            
+            
+            Console.WriteLine($"Step: ({GetType().Name}) failed with Exception: ({e.Message})");
+            return e;
         }
     }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>2.1.5</Version>
+        <Version>2.2.0</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Stack Traces from Steps were previously being eaten when thrown at the Workflow level due to the Run() function simply calling .Unwrap().

Using LanguageExt's Rethrow() function, the original stack trace is preserved.

The Step method will also now update the stack trace with a JSON message including its' type, original message, and the step it was thrown in.