### PR TITLE
fix: RunEither Memory Reset

### DIFF
--- a/ChainSharp/Workflow/Workflow.cs
+++ b/ChainSharp/Workflow/Workflow.cs
@@ -26,7 +26,7 @@ public abstract partial class Workflow<TInput, TReturn> : IWorkflow<TInput, TRet
     public Task<Either<Exception, TReturn>> RunEither(TInput input)
     {
         // Always allow input type of Unit for parameterless invocation
-        Memory = new Dictionary<Type, object> { { typeof(Unit), Unit.Default } };
+        Memory ??= new Dictionary<Type, object> { { typeof(Unit), Unit.Default } };
 
         return RunInternal(input);
     }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>2.2.1</Version>
+        <Version>2.2.2</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
If a function like AddServices() is called before actually running a workflow, Memory will be reset.

We don't want this functionality such that outside services can be injected into the container separate from what the workflow calls for.