### PR TITLE
3.1.1 - ChainSharp.Effect Exception Handling

### DIFF
--- a/ChainSharp.Effect/Models/Metadata/Metadata.cs
+++ b/ChainSharp.Effect/Models/Metadata/Metadata.cs
@@ -94,16 +94,16 @@ public class Metadata : IMetadata
                 FailureException = workflowException.GetType().Name;
                 FailureReason = workflowException.Message;
                 FailureStep = "WorkflowException";
-                StackTrace = workflowException.StackTrace; 
+                StackTrace = workflowException.StackTrace;
             }
             else
             {
                 FailureException = deserializedException.Type;
                 FailureReason = deserializedException.Message;
                 FailureStep = deserializedException.Step;
-                StackTrace = workflowException.StackTrace; 
+                StackTrace = workflowException.StackTrace;
             }
-            
+
             return Unit.Default;
         }
         catch (Exception)
@@ -113,7 +113,7 @@ public class Metadata : IMetadata
             FailureStep = "WorkflowException";
             StackTrace = workflowException.StackTrace;
         }
-        
+
         return Unit.Default;
     }
 

--- a/ChainSharp.Effect/Models/Metadata/Metadata.cs
+++ b/ChainSharp.Effect/Models/Metadata/Metadata.cs
@@ -90,23 +90,31 @@ public class Metadata : IMetadata
             );
 
             if (deserializedException == null)
-                throw new Exception(
-                    $"Could not deserialize exception data from ({Name}) workflow."
-                );
-
-            FailureException = deserializedException.Type;
-            FailureReason = deserializedException.Message;
-            FailureStep = deserializedException.Step;
-            StackTrace = workflowException.StackTrace;
-
+            {
+                FailureException = workflowException.GetType().Name;
+                FailureReason = workflowException.Message;
+                FailureStep = "WorkflowException";
+                StackTrace = workflowException.StackTrace; 
+            }
+            else
+            {
+                FailureException = deserializedException.Type;
+                FailureReason = deserializedException.Message;
+                FailureStep = deserializedException.Step;
+                StackTrace = workflowException.StackTrace; 
+            }
+            
             return Unit.Default;
         }
-        catch (Exception e)
+        catch (Exception)
         {
-            throw new WorkflowException(
-                $"Found Exception Type ({e.GetType()}) with Message ({e.Message}). Could not deserialize exception data from ({Name}) workflow. This is likely because this function was not correctly called or the RailwayStep function did not process the exception Message correctly."
-            );
+            FailureException = workflowException.GetType().Name;
+            FailureReason = workflowException.Message;
+            FailureStep = "WorkflowException";
+            StackTrace = workflowException.StackTrace;
         }
+        
+        return Unit.Default;
     }
 
     #endregion

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>3.1.0</Version>
+        <Version>3.1.1</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
The AddException() function in Metadata.cs previously would throw if it could not deserialize an exception handed to it.

This ended up being a problem for WorkflowExceptions, as they wouldn't be formatted correctly. Now the function attempts to extract as much information as it can instead of throwing.