### PR TITLE
3.1.2 - Transient Effect Runner

### DIFF
--- a/ChainSharp.Effect/Extensions/ServiceExtensions.cs
+++ b/ChainSharp.Effect/Extensions/ServiceExtensions.cs
@@ -18,7 +18,7 @@ public static class ServiceExtensions
     {
         var configuration = BuildConfiguration(serviceCollection, options);
 
-        return serviceCollection.AddScoped<IEffectRunner, EffectRunner>();
+        return serviceCollection.AddTransient<IEffectRunner, EffectRunner>();
     }
 
     private static ChainSharpEffectConfiguration BuildConfiguration(

--- a/ChainSharp.Tests.Effect.Data.Postgres.Integration/IntegrationTests/PostgresContextTests.cs
+++ b/ChainSharp.Tests.Effect.Data.Postgres.Integration/IntegrationTests/PostgresContextTests.cs
@@ -67,7 +67,8 @@ public class PostgresContextTests : TestSetup
     {
         // Arrange
         var workflow = Scope.ServiceProvider.GetRequiredService<ITestWorkflowWithinWorkflow>();
-        var dataContextProvider = Scope.ServiceProvider.GetRequiredService<IDataContextProviderFactory>();
+        var dataContextProvider =
+            Scope.ServiceProvider.GetRequiredService<IDataContextProviderFactory>();
 
         // Act
         var innerWorkflow = await workflow.Run(Unit.Default);
@@ -85,13 +86,17 @@ public class PostgresContextTests : TestSetup
         innerWorkflow.Metadata.WorkflowState.Should().Be(WorkflowState.Completed);
 
         var dataContext = dataContextProvider.Create();
-        
-        var parentWorkflowResult = await dataContext.Metadatas.FirstOrDefaultAsync(x => x.Id == workflow.Metadata.Id);
-        var childWorkflowResult = await dataContext.Metadatas.FirstOrDefaultAsync(x => x.Id == innerWorkflow.Metadata.Id);
+
+        var parentWorkflowResult = await dataContext.Metadatas.FirstOrDefaultAsync(
+            x => x.Id == workflow.Metadata.Id
+        );
+        var childWorkflowResult = await dataContext.Metadatas.FirstOrDefaultAsync(
+            x => x.Id == innerWorkflow.Metadata.Id
+        );
         parentWorkflowResult.Should().NotBeNull();
         parentWorkflowResult!.Id.Should().Be(workflow.Metadata.Id);
         parentWorkflowResult!.WorkflowState.Should().Be(WorkflowState.Completed);
-        
+
         childWorkflowResult.Should().NotBeNull();
         childWorkflowResult!.Id.Should().Be(innerWorkflow.Metadata.Id);
         childWorkflowResult!.WorkflowState.Should().Be(WorkflowState.Completed);

--- a/ChainSharp.Tests.Effect.Data.Postgres.Integration/IntegrationTests/PostgresContextTests.cs
+++ b/ChainSharp.Tests.Effect.Data.Postgres.Integration/IntegrationTests/PostgresContextTests.cs
@@ -61,7 +61,7 @@ public class PostgresContextTests : TestSetup
         workflow.Metadata.FailureStep.Should().BeNullOrEmpty();
         workflow.Metadata.WorkflowState.Should().Be(WorkflowState.Completed);
     }
-    
+
     [Theory]
     public async Task TestPostgresProviderCanRunWorkflowWithinWorkflow()
     {
@@ -84,27 +84,26 @@ public class PostgresContextTests : TestSetup
         protected override async Task<Either<Exception, Unit>> RunInternal(Unit input) =>
             Activate(input).Resolve();
     }
-    
-    private class TestWorkflowWithinWorkflow(ITestWorkflow testWorkflow) : EffectWorkflow<Unit, Unit>, ITestWorkflowWithinWorkflow
+
+    private class TestWorkflowWithinWorkflow(ITestWorkflow testWorkflow)
+        : EffectWorkflow<Unit, Unit>,
+            ITestWorkflowWithinWorkflow
     {
         protected override async Task<Either<Exception, Unit>> RunInternal(Unit input) =>
-            Activate(input)
-                .AddServices(testWorkflow)
-                .Chain<StepToRunTestWorkflow>()
-                .Resolve();
+            Activate(input).AddServices(testWorkflow).Chain<StepToRunTestWorkflow>().Resolve();
     }
-    
+
     private class StepToRunTestWorkflow(ITestWorkflow testWorkflow) : Step<Unit, Unit>
     {
         public override async Task<Unit> Run(Unit input)
         {
             await testWorkflow.Run(Unit.Default);
-            
+
             return Unit.Default;
         }
     }
 
     private interface ITestWorkflow : IEffectWorkflow<Unit, Unit> { }
-    
+
     private interface ITestWorkflowWithinWorkflow : IEffectWorkflow<Unit, Unit> { }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>3.1.1</Version>
+        <Version>3.1.2</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
If Workflow A was ran *within* Workflow B, B would finish *before* A.

Therefore, the EffectRunner would save its changes, then Dispose. Therefore the Effects still open on workflow A would *also* be Disposed.

The EffectRunner must be a Transient service to avoid this.